### PR TITLE
Fix ULDM class issues & nfw_tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/tests/test_halos/test_uldm.py
+++ b/tests/test_halos/test_uldm.py
@@ -11,7 +11,7 @@ class TestULDMHalo(object):
 
     def setup(self):
 
-        mass = 10**8.
+        mass = 1e8
         x = 0.5
         y = 1.
         r3d = np.sqrt(1 + 0.5 ** 2 + 70**2)
@@ -66,7 +66,9 @@ class TestULDMHalo(object):
 
     def test_profile_load(self):
 
-        single_halo = SingleHalo(10**8, 0.5, 0.5, 100, 'ULDM', 0.5, 0.5, 1.5, True)
+        profile_args = {'m_uldm': 8e-23, 'uldm_plaw': 1/3}
+
+        single_halo = SingleHalo(8e9, 0.5, 0.5, 100, 'ULDM', 0.5, 0.5, 1.5, True, profile_args)
         lens_model_list, redshift_array, kwargs_lens, numerical_interp = single_halo.\
             lensing_quantities(add_mass_sheet_correction=False)
         npt.assert_string_equal(lens_model_list[1], 'ULDM')


### PR DESCRIPTION
- Removed ULDM defaults
- Added equation references
- Mass budget scaled at r200
- ULDM virial mass now set to NFW virial mass (for determining core radius and density)
- Error message for negative mass moved
- ULDM test function parameters modified to avoid error
- 'nfw_tables' deletion bug fixed