### PR TITLE
Added averaging to fluctuations

### DIFF
--- a/pyHalo/preset_models.py
+++ b/pyHalo/preset_models.py
@@ -262,7 +262,7 @@ def ULDM(z_lens, z_source, log10_m_uldm, velocity_scale=200, log_mlow=6., log_mh
                   c_scale=15., c_power=-0.3, cone_opening_angle_arcsec=6.,
                   sigma_sub=0.025, LOS_normalization=1., log_m_host= 13.3, power_law_index=-1.9, r_tidal='0.25Rs',
                   mass_definition='ULDM', uldm_plaw=1/3, scale_nfw=False, flucs=True,
-                  flucs_shape='aperture',flucs_args={}, einstein_radius=6.,**kwargs_other):
+                  flucs_shape='aperture',flucs_args={}, einstein_radius=6., n_cut=5e4, **kwargs_other):
 
     """
     This generates realizations of ultra-light dark matter (ULDM), including the ULDM halo mass function and halo density profiles,
@@ -340,6 +340,7 @@ def ULDM(z_lens, z_source, log10_m_uldm, velocity_scale=200, log_mlow=6., log_mh
     :param flucs_shape: String specifying how to place fluctuations, see docs in realization_extensions.add_ULDM_fluctuations
     :param fluc_args: Keyword arguments for specifying the fluctuations, see docs in realization_extensions.add_ULDM_fluctuations
     :param einstein_radius: Einstein radius of main deflector halo in kpc
+    :param n_cut: Number of fluctuations above which to start cancelling
     :param kwargs_other: any other optional keyword arguments
     :return: a realization of ULDM halos
     """
@@ -396,7 +397,8 @@ def ULDM(z_lens, z_source, log10_m_uldm, velocity_scale=200, log_mlow=6., log_mh
                                 fluctuation_amplitude_variance=delta_kappa,
                                 fluctuation_size_variance=lambda_dB,
                                 shape=flucs_shape,
-                                args=flucs_args)
+                                args=flucs_args,
+                                n_cut=n_cut)
 
     return uldm_realization
 

--- a/pyHalo/realization_extensions.py
+++ b/pyHalo/realization_extensions.py
@@ -242,15 +242,14 @@ class RealizationExtensions(object):
 
         # get number of fluctuations
         n_flucs = _get_number_flucs(self._realization,de_Broglie_wavelength,shape,args)
-        
-        print()
+
         # if zero fluctuations, return original realization
         if shape!='aperture':
             if n_flucs==0:
                 return self._realization
             if n_flucs > n_cut: #supress amplitudes by # of cancellations if above n_cut
                 fluctuation_amplitude_variance /= np.sqrt(n_flucs/n_cut) 
-                n_flucs = n_cut
+                n_flucs = int(n_cut)
         if shape=='aperture':
             if len(n_flucs)==0: #empty array if all apertures have zero fluctuations
                 return self._realization

--- a/tests/test_realization_extensions.py
+++ b/tests/test_realization_extensions.py
@@ -97,21 +97,22 @@ class TestRealizationExtensions(object):
         wavelength=0.6 #kpc, correpsonds to m=10^-22 eV for ULDM
         amp_var = 0.04 #in convergence units
         fluc_var = wavelength
+        n_cut = 1e4
 
         # apeture
         x_images = np.array([-0.347, -0.734, -1.096, 0.207])
         y_images = np.array([ 0.964,  0.649, -0.079, -0.148])
         args_aperture = {'x_images':x_images,'y_images':y_images,'aperture':0.25}
         
-        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='aperture',args=args_aperture)
+        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='aperture',args=args_aperture, n_cut=n_cut)
 
         #ring
         args_ring = {'rmin':0.95,'rmax':1.05}
-        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='ring',args=args_ring)
+        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='ring',args=args_ring, n_cut=n_cut)
 
         #ellipse
         args_ellipse = {'amin':0.8,'amax':1.7,'bmin':0.4,'bmax':1.2,'angle':np.pi/4}
-        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='ellipse',args=args_ellipse)
+        ext.add_ULDM_fluctuations(wavelength,amp_var,fluc_var,shape='ellipse',args=args_ellipse, n_cut=n_cut)
 
     def test_add_pbh(self):
 


### PR DESCRIPTION
Added n_cut parameter. If the number of fluctuations is above n_cut, only n_cut fluctuations are rendered and the amplitudes are suppressed by sqrt( n_flucs / n_cut ). 

For the case of apertures, I just take the average number of fluctuations in the apertures and check if its above n_cut. I don't think this should matter much since we are are only cancelling at large n.

For reference, for a 0.25 arcsec aperture, 10^-20 eV renders 60,000 fluctuations and 10^-19.5 renders 600,000 fluctuations. So a reasonable value for n_cut should be something like order 10,000.