### PR TITLE
multiplane_convergence in utilities

### DIFF
--- a/pyHalo/utilities.py
+++ b/pyHalo/utilities.py
@@ -363,7 +363,7 @@ def multiplane_convergence(realization, cone_opening_angle_arcsec=2.5, npix=100,
                            lens_redshift_list=redshift_list_macro + list(redshfit_array_halos),
                            cosmo=realization.lens_cosmo.cosmo.astropy)
 
-    _r = np.linspace(-cone_opening_angle_arcsec/2, cone_opening_angle_arcsec/2, npix)
+    _r = np.linspace(-cone_opening_angle_arcsec/4, cone_opening_angle_arcsec/4, npix)
     xx, yy = np.meshgrid(_r, _r)
     kappa_macro = lens_model_macro.kappa(xx.ravel(), yy.ravel(), kwargs_lens_macro)
     kappa = lens_model.kappa(xx.ravel(), yy.ravel(), kwargs_lens_macro + kwargs_lens_halos)


### PR DESCRIPTION
@dangilman A kappa map generated by the multiplane_convergence imported from pyHalo.utilities is twice as big as the lensed picture. This choice, in my opinion, lengthens the computation of correlation by at least four times. To fix this, I modified multiplane_convergence function in pyHalo.utilities.