### PR TITLE
change default tidal truncation model and redshift/host mass scaling …

### DIFF
--- a/pyHalo/Halos/HaloModels/generalized_nfw.py
+++ b/pyHalo/Halos/HaloModels/generalized_nfw.py
@@ -1,5 +1,5 @@
 from pyHalo.Halos.halo_base import Halo
-from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import PseudoDoublePowerlaw
 import numpy as np
 
 class GeneralNFWSubhalo(Halo):
@@ -15,7 +15,7 @@ class GeneralNFWSubhalo(Halo):
         """
         See documentation in base class (Halos/halo_base.py)
         """
-        self._prof = GNFW()
+        self._prof = PseudoDoublePowerlaw()
         self._lens_cosmo = lens_cosmo_instance
         self._truncation_class = truncation_class
         self._concentration_class = concentration_class

--- a/pyHalo/Halos/HaloModels/generalized_nfw.py
+++ b/pyHalo/Halos/HaloModels/generalized_nfw.py
@@ -19,7 +19,7 @@ class GeneralNFWSubhalo(Halo):
         self._lens_cosmo = lens_cosmo_instance
         self._truncation_class = truncation_class
         self._concentration_class = concentration_class
-        mdef = 'GNFW'
+        mdef = 'PSEUDO_DPL'
         super(GeneralNFWSubhalo, self).__init__(mass, x, y, r3d, mdef, z, sub_flag,
                                               lens_cosmo_instance, args, unique_tag)
 

--- a/pyHalo/Halos/HaloModels/generalized_nfw.py
+++ b/pyHalo/Halos/HaloModels/generalized_nfw.py
@@ -57,7 +57,7 @@ class GeneralNFWSubhalo(Halo):
         """
         See documentation in base class (Halos/halo_base.py)
         """
-        return ['GNFW']
+        return ['PSEUDO_DPL']
 
     @property
     def profile_args(self):

--- a/pyHalo/Halos/tidal_truncation.py
+++ b/pyHalo/Halos/tidal_truncation.py
@@ -25,7 +25,7 @@ class TruncationSplashBack(object):
 
     def truncation_radius(self, halo_mass, z):
         """
-        Computes the radius r_N of an NFW halo
+        Computes the truncation radius as the splashback radius an NFW halo
         :param halo_mass: halo mass (m200 with respect to critical density at z)
         :param z: redshift
         :param halo_concentration: the halo concentration

--- a/pyHalo/PresetModels/cdm.py
+++ b/pyHalo/PresetModels/cdm.py
@@ -12,11 +12,11 @@ from pyHalo.truncation_models import truncation_models
 def CDM(z_lens, z_source, sigma_sub=0.025, log_mlow=6., log_mhigh=10., log10_sigma_sub=None,
         concentration_model_subhalos='DIEMERJOYCE19', kwargs_concentration_model_subhalos={},
         concentration_model_fieldhalos='DIEMERJOYCE19', kwargs_concentration_model_fieldhalos={},
-        truncation_model_subhalos='TRUNCATION_ROCHE_GILMAN2020', kwargs_truncation_model_subhalos={},
+        truncation_model_subhalos='TRUNCATION_GALACTICUS', kwargs_truncation_model_subhalos={},
         truncation_model_fieldhalos='TRUNCATION_RN', kwargs_truncation_model_fieldhalos={},
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3,  r_tidal=0.25,
         LOS_normalization=1.0, two_halo_contribution=True, delta_power_law_index=0.0,
-        geometry_type='DOUBLE_CONE', kwargs_cosmo=None, host_scaling_factor=0.88, redshift_scaling_factor=1.7):
+        geometry_type='DOUBLE_CONE', kwargs_cosmo=None, host_scaling_factor=0.5, redshift_scaling_factor=0.3):
     """
     This class generates realizations of dark matter structure in Cold Dark Matter
 

--- a/pyHalo/PresetModels/sidm.py
+++ b/pyHalo/PresetModels/sidm.py
@@ -7,7 +7,7 @@ def SIDM_core_collapse(z_lens, z_source, mass_ranges_subhalos, mass_ranges_field
         kwargs_field_function=None, sigma_sub=0.025, log10_sigma_sub=None, log_mlow=6., log_mhigh=10.,
         concentration_model_subhalos='DIEMERJOYCE19', kwargs_concentration_model_subhalos={},
         concentration_model_fieldhalos='DIEMERJOYCE19', kwargs_concentration_model_fieldhalos={},
-        truncation_model_subhalos='TRUNCATION_ROCHE_GILMAN2020', kwargs_truncation_model_subhalos={},
+        truncation_model_subhalos='TRUNCATION_GALACTICUS', kwargs_truncation_model_subhalos={},
         truncation_model_fieldhalos='TRUNCATION_RN', kwargs_truncation_model_fieldhalos={},
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3,  r_tidal=0.25,
         LOS_normalization=1.0, geometry_type='DOUBLE_CONE', kwargs_cosmo=None, collapsed_halo_profile='SPL_CORE',

--- a/pyHalo/PresetModels/uldm.py
+++ b/pyHalo/PresetModels/uldm.py
@@ -14,7 +14,7 @@ def ULDM(z_lens, z_source, log10_m_uldm, log10_fluc_amplitude=-0.8, fluctuation_
         mass_function_model_fieldhalos='SCHIVE2016', kwargs_mass_function_fieldhalos={},
         concentration_model_subhalos='LAROCHE2022', kwargs_concentration_model_subhalos={},
         concentration_model_fieldhalos='LAROCHE2022', kwargs_concentration_model_fieldhalos={},
-        truncation_model_subhalos='TRUNCATION_ROCHE_GILMAN2020', kwargs_truncation_model_subhalos={},
+        truncation_model_subhalos='TRUNCATION_GALACTICUS', kwargs_truncation_model_subhalos={},
         truncation_model_fieldhalos='TRUNCATION_RN', kwargs_truncation_model_fieldhalos={},
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3, r_tidal=0.25,
         LOS_normalization=1.0, geometry_type='DOUBLE_CONE', kwargs_cosmo=None,

--- a/pyHalo/PresetModels/wdm.py
+++ b/pyHalo/PresetModels/wdm.py
@@ -12,7 +12,7 @@ def WDM(z_lens, z_source, log_mc, sigma_sub=0.025, log_mlow=6., log_mhigh=10., l
         mass_function_model_fieldhalos='LOVELL2020', kwargs_mass_function_fieldhalos={},
         concentration_model_subhalos='BOSE2016', kwargs_concentration_model_subhalos={},
         concentration_model_fieldhalos='BOSE2016', kwargs_concentration_model_fieldhalos={},
-        truncation_model_subhalos='TRUNCATION_ROCHE_GILMAN2020', kwargs_truncation_model_subhalos={},
+        truncation_model_subhalos='TRUNCATION_GALACTICUS', kwargs_truncation_model_subhalos={},
         truncation_model_fieldhalos='TRUNCATION_RN', kwargs_truncation_model_fieldhalos={},
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3, r_tidal=0.25,
         LOS_normalization=1.0, geometry_type='DOUBLE_CONE', kwargs_cosmo=None,
@@ -167,7 +167,7 @@ def WDM_mixed(z_lens, z_source, log_mc, mixed_DM_frac, sigma_sub=0.025, log_mlow
         mass_function_model_fieldhalos='MIXED_WDM_TURNOVER', kwargs_mass_function_fieldhalos={},
         concentration_model_subhalos='BOSE2016', kwargs_concentration_model_subhalos={},
         concentration_model_fieldhalos='BOSE2016', kwargs_concentration_model_fieldhalos={},
-        truncation_model_subhalos='TRUNCATION_ROCHE_GILMAN2020', kwargs_truncation_model_subhalos={},
+        truncation_model_subhalos='TRUNCATION_GALACTICUS', kwargs_truncation_model_subhalos={},
         truncation_model_fieldhalos='TRUNCATION_RN', kwargs_truncation_model_fieldhalos={},
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3, r_tidal=0.25,
         LOS_normalization=1.0, geometry_type='DOUBLE_CONE', kwargs_cosmo=None,
@@ -243,7 +243,7 @@ def WDMGeneral(z_lens, z_source, log_mc, dlogT_dlogk, sigma_sub=0.025, log_mlow=
         shmf_log_slope=-1.9, cone_opening_angle_arcsec=6., log_m_host=13.3, r_tidal=0.25,
         LOS_normalization=1.0, geometry_type='DOUBLE_CONE', kwargs_cosmo=None,
         mdef_subhalos='TNFW', mdef_field_halos='TNFW', kwargs_density_profile={},
-               host_scaling_factor=0.88, redshift_scaling_factor=1.7):
+               host_scaling_factor=0.5, redshift_scaling_factor=0.3):
 
     """
     This preset model implements a generalized treatment of warm dark matter, or any theory that produces a cutoff in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyhalo"
-version = "1.1.1"
+version = "1.2.0"
 authors = [
   { name="Daniel Gilman", email="gilmanda@uchicago.edu" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [ ]
 
 setup(
     author="Daniel Gilman",
-    version='1.1.1',
+    version='1.2.0',
     author_email='daniel.gilman@utoronto.ca',
     classifiers=[
         'Development Status :: 5 - Stable',

--- a/tests/test_halos/test_general_nfw.py
+++ b/tests/test_halos/test_general_nfw.py
@@ -4,7 +4,7 @@ from pyHalo.Halos.lens_cosmo import LensCosmo
 from pyHalo.Halos.HaloModels.generalized_nfw import GeneralNFWFieldHalo, GeneralNFWSubhalo
 from pyHalo.Halos.HaloModels.NFW import NFWFieldHalo
 from pyHalo.Halos.concentration import ConcentrationDiemerJoyce
-from lenstronomy.LensModel.Profiles.general_nfw import GNFW
+from lenstronomy.LensModel.Profiles.pseudo_double_powerlaw import PseudoDoublePowerlaw
 from lenstronomy.LensModel.Profiles.nfw import NFW
 import pytest
 from astropy.cosmology import FlatLambdaCDM
@@ -20,7 +20,7 @@ class TestGeneralNFW(object):
         self.zsource = 2.0
         self.lens_cosmo = LensCosmo(self.zhalo, self.zsource, cosmo)
         self.nfw_profile_lenstronomy = NFW()
-        self.gnfw_profile_lenstronomy = GNFW()
+        self.gnfw_profile_lenstronomy = PseudoDoublePowerlaw()
         self.truncation_class = None
         self.concentration_class = ConcentrationDiemerJoyce(self.lens_cosmo, scatter=False)
 

--- a/tests/test_halos/test_general_nfw.py
+++ b/tests/test_halos/test_general_nfw.py
@@ -49,7 +49,7 @@ class TestGeneralNFW(object):
         npt.assert_almost_equal(rs/kwargs_gnfw_profile['Rs'], 1.0, 4)
 
         id = gnfw.lenstronomy_ID
-        npt.assert_string_equal('GNFW', id[0])
+        npt.assert_string_equal('PSEUDO_DPL', id[0])
 
     def test_enclosed_mass(self):
 


### PR DESCRIPTION
This pull request changes the default tidal truncation model to TRUNCATION_GALACTICUS, which uses halo concentration at infall, host concentration, and the time since infall to compute the tidal truncation radius of subhalos. Also, this pull request updates the default scaling with host halo mass and redshift to new values calibrated against a more up-to-date version of galacticus (Gannon et al. in prep)