### PR TITLE
Change scipy.integrate.simps to scipy.integrate.simpson

### DIFF
--- a/pyHalo/realization_extensions.py
+++ b/pyHalo/realization_extensions.py
@@ -11,7 +11,7 @@ from pyHalo.Rendering.SpatialDistributions.uniform import Uniform
 from copy import deepcopy
 from scipy.interpolate import RectBivariateSpline
 import time
-from scipy.integrate import simps
+from scipy.integrate import simpson as simps
 from scipy.special import eval_chebyt
 from scipy.optimize import curve_fit
 from mcfit import Hankel

--- a/pyHalo/utilities.py
+++ b/pyHalo/utilities.py
@@ -4,7 +4,7 @@ from scipy.interpolate import interp1d
 from pyHalo.Cosmology.cosmology import Cosmology
 from scipy.integrate import quad
 from pyHalo.Halos.lens_cosmo import LensCosmo
-from scipy.integrate import simps
+from scipy.integrate import simpson as simps
 from pyHalo.concentration_models import preset_concentration_models
 from lenstronomy.LensModel.lens_model import LensModel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Sphinx==1.7.1
 twine==1.10.0
 numpy>1.23
 astropy>=2.0
-scipy>=0.19.1
+scipy>=1.6.0
 colossus>=1.3.1
 h5py>=3.9.0
 mcfit>=0.0.21

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,6 @@
 from lenstronomy.LensModel.lens_model import LensModel
 import numpy.testing as npt
-from scipy.integrate import simps
+from scipy.integrate import simpson as simps
 import numpy as np
 from pyHalo.utilities import interpolate_ray_paths, de_broglie_wavelength, delta_sigma, ITSampling, \
     inverse_transform_sampling, delta_kappa, nfw_velocity_dispersion


### PR DESCRIPTION
Replaced instances of "from scipy.integrate import simps" to "from scipy.integrate import simpson as simps". This will break compatibility with scipy<1.6.0 but will enable use of scipy>=1.14.0.