### PR TITLE
evaluate rhos and rs at infall redshift

### DIFF
--- a/pyHalo/Halos/HaloModels/NFW_core_trunc.py
+++ b/pyHalo/Halos/HaloModels/NFW_core_trunc.py
@@ -24,6 +24,15 @@ class TNFWCHalo(Halo):
         super(TNFWCHalo, self).__init__(mass, x, y, r3d, mdef, z, sub_flag,
                                            lens_cosmo_instance, args, unique_tag)
 
+    def density_profile_3d(self, r, profile_args=None):
+        """
+
+        :param r:
+        :param profile_args:
+        :return:
+        """
+        return self.density_profile_3d_lenstronomy(r)
+
     def density_profile_3d_lenstronomy(self, r, kwargs_lenstronomy=None):
         """
         Computes the 3-D density profile of the halo
@@ -269,7 +278,7 @@ def tnfwc_mass(rmax, rho, rs, rc):
 
 def evolve_profile(t, rs_0):
 
-    t = min(1.5, t)
+    t = min(1.6, t)
     rs = rs_0 * rs_evolution(t)
     rc = rs_0 * rc_evolution(t)
     return rs, rc

--- a/pyHalo/Halos/halo_base.py
+++ b/pyHalo/Halos/halo_base.py
@@ -193,7 +193,7 @@ class Halo(ABC):
     @property
     def z_eval(self):
         """
-        Returns the redshift at which to evaluate the concentration-mass relation
+        Returns the redshift at which to evaluate the concentration-mass relation and NFW halo parameters
         """
         if not hasattr(self, '_zeval'):
 
@@ -214,7 +214,7 @@ class Halo(ABC):
         :return: rs, r200 and rho_s in units kpc, kpc, and M_sun / kpc^3
         """
         if not hasattr(self, '_nfw_params'):
-            rhos, rs, r200 = self.lens_cosmo.NFW_params_physical(self.mass, self.c, self.z, self._pseudo_nfw)
+            rhos, rs, r200 = self.lens_cosmo.NFW_params_physical(self.mass, self.c, self.z_eval, self._pseudo_nfw)
             self._nfw_params = [rhos, rs, r200]
         return self._nfw_params[0], self._nfw_params[1], self._nfw_params[2]
 

--- a/pyHalo/realization_extensions.py
+++ b/pyHalo/realization_extensions.py
@@ -271,12 +271,13 @@ class RealizationExtensions(object):
         if halo.is_subhalo:
             subhalo_flag = True
             kwargs_profile['lambda_t'] = subhalo_evolution_scaling
+            r = halo.nfw_params[1] * np.linspace(min(0.01 * tau, 0.01), halo.c, 5000)
+            rho = halo.density_profile_3d_lenstronomy(r)
+            kwargs_profile['mass_conservation'] = np.trapz(4 * np.pi * r ** 2 * rho, r)
         else:
             subhalo_flag = False
             kwargs_profile['lambda_t'] = 1.0
-        r = halo.nfw_params[1] * np.linspace(min(0.01 * tau, 0.01), halo.c, 20000)
-        rho = halo.density_profile_3d_lenstronomy(r)
-        kwargs_profile['mass_conservation'] = np.trapz(4 * np.pi * r ** 2 * rho, r)
+            kwargs_profile['mass_conservation'] = halo.mass_3d('r200')
         new_halo = TNFWCHalo(halo.mass, halo.x, halo.y, halo.r3d, halo.z, subhalo_flag,
                                       halo.lens_cosmo, kwargs_profile,
                                       truncation_class,


### PR DESCRIPTION
fix a discrepancy where the rhos, rs parameters for subhalos are evaluated at the lens redshift rather than infall redshift 