### PR TITLE
modified files so that pyHalo becomes compatible with the normalizing flows pipeline

### DIFF
--- a/pyHalo/preset_models.py
+++ b/pyHalo/preset_models.py
@@ -33,9 +33,9 @@ def preset_model_from_name(name, custom_function=None):
     elif name == 'ULDM':
         from pyHalo.PresetModels.uldm import ULDM
         return ULDM
-    elif name == 'CDMEmulator':
-        from pyHalo.PresetModels.external import CDMFromEmulator
-        return CDMFromEmulator
+    elif name == 'DMEmulator':
+        from pyHalo.PresetModels.external import DMFromEmulator
+        return DMFromEmulator
     elif name == 'WDM_mixed':
         from pyHalo.PresetModels.wdm import WDM_mixed
         return WDM_mixed


### PR DESCRIPTION
Both pyHalo/preset_models.py and pyHalo/PresetModels/external.py are modified to incorporate a "DMFromEmulator" class which creates either a population of emulated subhalos from the normalizing flows algorithm. This class is currently used to generate both CDM and WDM emulated subhalo populations.