### PR TITLE
updated emulator syntax to read preset_models.py

### DIFF
--- a/pyHalo/preset_models.py
+++ b/pyHalo/preset_models.py
@@ -33,8 +33,8 @@ def preset_model_from_name(name, custom_function=None):
     elif name == 'ULDM':
         from pyHalo.PresetModels.uldm import ULDM
         return ULDM
-    elif name == 'DMEmulator':
-        from pyHalo.PresetModels.external import DMFromEmulator
+    elif name == 'DMSubhalosEmulator':
+        from pyHalo.PresetModels.external import DMSubhalosFromEmulator
         return DMFromEmulator
     elif name == 'WDM_mixed':
         from pyHalo.PresetModels.wdm import WDM_mixed

--- a/pyHalo/preset_models.py
+++ b/pyHalo/preset_models.py
@@ -35,7 +35,7 @@ def preset_model_from_name(name, custom_function=None):
         return ULDM
     elif name == 'DMSubhalosEmulator':
         from pyHalo.PresetModels.external import DMSubhalosFromEmulator
-        return DMFromEmulator
+        return DMSubhalosFromEmulator
     elif name == 'WDM_mixed':
         from pyHalo.PresetModels.wdm import WDM_mixed
         return WDM_mixed


### PR DESCRIPTION
Code is adjusted to call "DMSubhalosEmulator" instead of "DMEmulator" and returns the DMSubhalosFromEmulator class.